### PR TITLE
fix(about): drop the two off-discipline interests

### DIFF
--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -719,14 +719,8 @@ $border-radius: 3px;
 					i.cp {
 						background-image: baseurl('icons/algorithm.svg');
 					}
-					i.back {
-						background-image: baseurl('icons/server.svg');
-					}
 					i.more {
 						background-image: baseurl('icons/web-development.svg');
-					}
-					i.game {
-						background-image: baseurl('icons/pacman.svg');
 					}
 				}
 			}

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -76,14 +76,6 @@ class About extends React.Component<AboutProps> {
                     <i className="ml"> </i>
                     MLOps{" "}
                   </li>{" "}
-                  <li className="About__interests__item">
-                    <i className="game"> </i>
-                    ChatBOT Development{" "}
-                  </li>{" "}
-                  <li className="About__interests__item">
-                    <i className="back"> </i>
-                    Data, data and more data{" "}
-                  </li>{" "}
                 </ul>{" "}
               </div>{" "}
             </div>{" "}


### PR DESCRIPTION
Follow-up to #62. Removes the two Interests entries flagged there.

**Before**

> Site Reliability Engineering · DevOps · Chaos Engineering · MLOps · ChatBOT Development · Data, data and more data

**After**

> Site Reliability Engineering · DevOps · Chaos Engineering · MLOps

"ChatBOT Development" was the last survivor of the old *"I also like to develop BOT"* positioning that the blog byline carried until it was corrected earlier in this series.

Also deletes the `i.game` and `i.back` rules from `index.scss` — they only ever styled the icons on those two items, and nothing references them now.

Mobile height 2,877px → 2,789px. Build clean, typecheck clean, 0 broken images, 0 horizontal overflow, Interests verified in the built output as exactly the four entries above.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Au8GGyhkzTaFpqNQdsFqZ)_